### PR TITLE
Replace error search string in erc1820 migration

### DIFF
--- a/migrations/2_erc1820_registry.js
+++ b/migrations/2_erc1820_registry.js
@@ -10,7 +10,7 @@ module.exports = async function (deployer, network, accounts) {
   web3.eth.sendSignedTransaction(rawTx).then((res) => {
     console.log('\n   > ERC1820 deployment: Success -->', res.contractAddress);
   }).catch((err) => {
-    if (err.message.search('nonce too low') >= 0) {
+    if (err.message.search(/the tx doesn\'t have the correct nonce|nonce is too low/g) >= 0) {
       console.log('\n   > ERC1820 deployment: Invalid nonce, probably already deployed');
     } else {
       console.log('\n   > ERC1820 deployment: Unknown error', err);


### PR DESCRIPTION
The error returned on deployment failure was not the same as the error catched in the migration file.