### PR TITLE
feat(whitelist): Require whitelisting both the sender and recipient +…

### DIFF
--- a/contracts/ERC1400.sol
+++ b/contracts/ERC1400.sol
@@ -53,10 +53,10 @@ contract ERC1400 is IERC1400, ERC1410, MinterRole {
     uint256 granularity,
     address[] memory controllers,
     address certificateSigner,
-    bytes32[] memory tokenDefaultPartitions
+    bytes32[] memory defaultPartitions
   )
     public
-    ERC1410(name, symbol, granularity, controllers, certificateSigner, tokenDefaultPartitions)
+    ERC1410(name, symbol, granularity, controllers, certificateSigner, defaultPartitions)
   {
     setInterfaceImplementation("ERC1400Token", address(this));
     _isControllable = true;
@@ -372,28 +372,6 @@ contract ERC1400 is IERC1400, ERC1410, MinterRole {
   /************* ERC1410/ERC777 BACKWARDS RETROCOMPATIBILITY ******************/
 
   /**
-   * [NOT MANDATORY FOR ERC1400 STANDARD]
-   * @dev Get token default partitions to send from.
-   * Function used for ERC777 and ERC20 backwards compatibility.
-   * For example, a security token may return the bytes32("unrestricted").
-   * @return Default partitions.
-   */
-  function getTokenDefaultPartitions() external view returns (bytes32[] memory) {
-    return _tokenDefaultPartitions;
-  }
-
-  /**
-   * [NOT MANDATORY FOR ERC1400 STANDARD]
-   * @dev Set token default partitions to send from.
-   * Function used for ERC777 and ERC20 backwards compatibility.
-   * @param defaultPartitions Partitions to use by default when not specified.
-   */
-  function setTokenDefaultPartitions(bytes32[] calldata defaultPartitions) external onlyOwner {
-    _tokenDefaultPartitions = defaultPartitions;
-  }
-
-
-  /**
    * [NOT MANDATORY FOR ERC1400 STANDARD][OVERRIDES ERC1410 METHOD]
    * @dev Redeem the value of tokens from the address 'msg.sender'.
    * @param value Number of tokens to redeem.
@@ -443,20 +421,19 @@ contract ERC1400 is IERC1400, ERC1410, MinterRole {
   )
     internal
   {
-    bytes32[] memory _partitions = _getDefaultPartitions(from);
-    require(_partitions.length != 0, "A8: Transfer Blocked - Token restriction");
+    require(_defaultPartitions.length != 0, "A8: Transfer Blocked - Token restriction");
 
     uint256 _remainingValue = value;
     uint256 _localBalance;
 
-    for (uint i = 0; i < _partitions.length; i++) {
-      _localBalance = _balanceOfByPartition[from][_partitions[i]];
+    for (uint i = 0; i < _defaultPartitions.length; i++) {
+      _localBalance = _balanceOfByPartition[from][_defaultPartitions[i]];
       if(_remainingValue <= _localBalance) {
-        _redeemByPartition(_partitions[i], operator, from, _remainingValue, data, operatorData);
+        _redeemByPartition(_defaultPartitions[i], operator, from, _remainingValue, data, operatorData);
         _remainingValue = 0;
         break;
       } else {
-        _redeemByPartition(_partitions[i], operator, from, _localBalance, data, operatorData);
+        _redeemByPartition(_defaultPartitions[i], operator, from, _localBalance, data, operatorData);
         _remainingValue = _remainingValue - _localBalance;
       }
     }

--- a/contracts/token/ERC1410/IERC1410.sol
+++ b/contracts/token/ERC1410/IERC1410.sol
@@ -19,7 +19,7 @@ interface IERC1410 {
     function operatorTransferByPartition(bytes32 partition, address from, address to, uint256 value, bytes calldata data, bytes calldata operatorData) external returns (bytes32); // 4/10
 
     // Default Partition Management
-    function getDefaultPartitions(address tokenHolder) external view returns (bytes32[] memory); // 5/10
+    function getDefaultPartitions() external view returns (bytes32[] memory); // 5/10
     function setDefaultPartitions(bytes32[] calldata partitions) external; // 6/10
 
     // Operators

--- a/contracts/token/ERC20/ERC777ERC20.sol
+++ b/contracts/token/ERC20/ERC777ERC20.sol
@@ -24,8 +24,9 @@ contract ERC777ERC20 is IERC20, ERC777Issuable {
   /**
    * @dev Modifier to verify if sender and recipient are whitelisted.
    */
-  modifier isWhitelisted(address recipient) {
-    require(_whitelisted[recipient], "A3: Transfer Blocked - Sender lockup period not ended");
+  modifier areWhitelisted(address sender, address recipient) {
+    require(_whitelisted[sender], "A5: Transfer Blocked - Sender not eligible");
+    require(_whitelisted[recipient], "A6:	Transfer Blocked - Receiver not eligible");
     _;
   }
 
@@ -163,7 +164,7 @@ contract ERC777ERC20 is IERC20, ERC777Issuable {
    * @param value The amount to be transferred.
    * @return A boolean that indicates if the operation was successful.
    */
-  function transfer(address to, uint256 value) external isWhitelisted(to) returns (bool) {
+  function transfer(address to, uint256 value) external areWhitelisted(msg.sender, to) returns (bool) {
     _transferWithData("", msg.sender, msg.sender, to, value, "", "", false);
     return true;
   }
@@ -176,18 +177,17 @@ contract ERC777ERC20 is IERC20, ERC777Issuable {
    * @param value The amount of tokens to be transferred.
    * @return A boolean that indicates if the operation was successful.
    */
-  function transferFrom(address from, address to, uint256 value) external isWhitelisted(to) returns (bool) {
-    address _from = (from == address(0)) ? msg.sender : from;
-    require( _isOperatorFor(msg.sender, _from)
-      || (value <= _allowed[_from][msg.sender]), "A7: Transfer Blocked - Identity restriction");
+  function transferFrom(address from, address to, uint256 value) external areWhitelisted(from, to) returns (bool) {
+    require( _isOperatorFor(msg.sender, from)
+      || (value <= _allowed[from][msg.sender]), "A7: Transfer Blocked - Identity restriction");
 
-    if(_allowed[_from][msg.sender] >= value) {
-      _allowed[_from][msg.sender] = _allowed[_from][msg.sender].sub(value);
+    if(_allowed[from][msg.sender] >= value) {
+      _allowed[from][msg.sender] = _allowed[from][msg.sender].sub(value);
     } else {
-      _allowed[_from][msg.sender] = 0;
+      _allowed[from][msg.sender] = 0;
     }
 
-    _transferWithData("", msg.sender, _from, to, value, "", "", false);
+    _transferWithData("", msg.sender, from, to, value, "", "", false);
     return true;
   }
 

--- a/test/ERC1400.test.js
+++ b/test/ERC1400.test.js
@@ -54,7 +54,7 @@ var totalSupply;
 var balance;
 var balanceByPartition;
 
-var tokenDefaultPartitions;
+var defaultPartitions;
 
 const assertTransferEvent = (
   _logs,
@@ -337,24 +337,6 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
     });
   });
 
-  // SETDEFAULTPARTITIONS
-
-  describe('setDefaultPartitions', function () {
-    beforeEach(async function () {
-      this.token = await ERC1400.new('ERC1400Token', 'DAU', 1, [controller], CERTIFICATE_SIGNER, partitions);
-    });
-    it('sets defaults partition', async function () {
-      await this.token.setDefaultPartitions([partition1, partition2, partition3], { from: tokenHolder });
-
-      const defaultPartitions = await this.token.getDefaultPartitions(tokenHolder);
-
-      assert.equal(defaultPartitions.length, 3);
-      assert.equal(defaultPartitions[0], partition1); // dAuriel1 in hex
-      assert.equal(defaultPartitions[1], partition2); // dAuriel2 in hex
-      assert.equal(defaultPartitions[2], partition3); // dAuriel3 in hex
-    });
-  });
-
   // AUTHORIZE OPERATOR BY PARTITION
 
   describe('authorizeOperatorByPartition', function () {
@@ -573,28 +555,28 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
   });
 
   // SET/GET TOKEN DEFAULT PARTITIONS
-  describe('tokenDefaultPartitions', function () {
+  describe('defaultPartitions', function () {
     beforeEach(async function () {
       this.token = await ERC1400.new('ERC1400Token', 'DAU', 1, [controller], CERTIFICATE_SIGNER, partitions);
-      tokenDefaultPartitions = await this.token.getTokenDefaultPartitions();
-      assert.equal(tokenDefaultPartitions.length, 3);
-      assert.equal(tokenDefaultPartitions[0], partition1);
-      assert.equal(tokenDefaultPartitions[1], partition2);
-      assert.equal(tokenDefaultPartitions[2], partition3);
+      defaultPartitions = await this.token.getDefaultPartitions();
+      assert.equal(defaultPartitions.length, 3);
+      assert.equal(defaultPartitions[0], partition1);
+      assert.equal(defaultPartitions[1], partition2);
+      assert.equal(defaultPartitions[2], partition3);
     });
     describe('when the sender is the contract owner', function () {
       it('sets the list of token default partitions', async function () {
-        await this.token.setTokenDefaultPartitions(reversedPartitions, { from: owner });
-        tokenDefaultPartitions = await this.token.getTokenDefaultPartitions();
-        assert.equal(tokenDefaultPartitions.length, 3);
-        assert.equal(tokenDefaultPartitions[0], partition3);
-        assert.equal(tokenDefaultPartitions[1], partition1);
-        assert.equal(tokenDefaultPartitions[2], partition2);
+        await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
+        defaultPartitions = await this.token.getDefaultPartitions();
+        assert.equal(defaultPartitions.length, 3);
+        assert.equal(defaultPartitions[0], partition3);
+        assert.equal(defaultPartitions[1], partition1);
+        assert.equal(defaultPartitions[2], partition2);
       });
     });
     describe('when the sender is not the contract owner', function () {
       it('reverts', async function () {
-        await shouldFail.reverting(this.token.setTokenDefaultPartitions(reversedPartitions, { from: unknown }));
+        await shouldFail.reverting(this.token.setDefaultPartitions(reversedPartitions, { from: unknown }));
       });
     });
   });
@@ -1029,7 +1011,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
   // TRANSFERWITHDATA
 
   describe('transferWithData', function () {
-    describe('when tokenDefaultPartitions have been defined', function () {
+    describe('when defaultPartitions have been defined', function () {
       beforeEach(async function () {
         this.token = await ERC1400.new('ERC1400Token', 'DAU', 1, [controller], CERTIFICATE_SIGNER, partitions);
         await issueOnMultiplePartitions(this.token, owner, tokenHolder, partitions, [issuanceAmount, issuanceAmount, issuanceAmount]);
@@ -1037,7 +1019,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
       describe('when the sender has enough balance for those default partitions', function () {
         describe('when the sender has defined custom default partitions', function () {
           it('transfers the requested amount', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             await assertBalances(this.token, tokenHolder, partitions, [issuanceAmount, issuanceAmount, issuanceAmount]);
 
             await this.token.transferWithData(recipient, 2.5 * issuanceAmount, VALID_CERTIFICATE, { from: tokenHolder });
@@ -1046,7 +1028,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
             await assertBalances(this.token, recipient, partitions, [issuanceAmount, 0.5 * issuanceAmount, issuanceAmount]);
           });
           it('emits a sent event', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             const { logs } = await this.token.transferWithData(recipient, 2.5 * issuanceAmount, VALID_CERTIFICATE, { from: tokenHolder });
 
             assert.equal(logs.length, 1 + 2 * partitions.length);
@@ -1069,12 +1051,12 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
       });
       describe('when the sender does not have enough balance for those default partitions', function () {
         it('reverts', async function () {
-          await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+          await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
           await shouldFail.reverting(this.token.transferWithData(recipient, 3.5 * issuanceAmount, VALID_CERTIFICATE, { from: tokenHolder }));
         });
       });
     });
-    describe('when tokenDefaultPartitions have not been defined', function () {
+    describe('when defaultPartitions have not been defined', function () {
       it('reverts', async function () {
         this.token = await ERC1400.new('ERC1400Token', 'DAU', 1, [controller], CERTIFICATE_SIGNER, []);
         await issueOnMultiplePartitions(this.token, owner, tokenHolder, partitions, [issuanceAmount, issuanceAmount, issuanceAmount]);
@@ -1097,7 +1079,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
       describe('when defaultPartitions have been defined', function () {
         describe('when the sender has enough balance for those default partitions', function () {
           it('transfers the requested amount (when sender is specified)', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             await assertBalances(this.token, tokenHolder, partitions, [issuanceAmount, issuanceAmount, issuanceAmount]);
 
             await this.token.transferFromWithData(tokenHolder, recipient, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator });
@@ -1106,7 +1088,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
             await assertBalances(this.token, recipient, partitions, [issuanceAmount, 0.5 * issuanceAmount, issuanceAmount]);
           });
           it('transfers the requested amount (when sender is not specified)', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             await assertBalances(this.token, tokenHolder, partitions, [issuanceAmount, issuanceAmount, issuanceAmount]);
 
             await this.token.transferFromWithData(ZERO_ADDRESS, recipient, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: tokenHolder });
@@ -1115,7 +1097,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
             await assertBalances(this.token, recipient, partitions, [issuanceAmount, 0.5 * issuanceAmount, issuanceAmount]);
           });
           it('emits a sent event', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             const { logs } = await this.token.transferFromWithData(tokenHolder, recipient, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator });
 
             assert.equal(logs.length, 1 + 2 * partitions.length);
@@ -1127,21 +1109,21 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
         });
         describe('when the sender does not have enough balance for those default partitions', function () {
           it('reverts', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             await shouldFail.reverting(this.token.transferFromWithData(tokenHolder, recipient, 3.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator }));
           });
         });
       });
       describe('when defaultPartitions have not been defined', function () {
         it('reverts', async function () {
-          await this.token.setTokenDefaultPartitions([], { from: owner });
+          await this.token.setDefaultPartitions([], { from: owner });
           await shouldFail.reverting(this.token.transferFromWithData(tokenHolder, recipient, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator }));
         });
       });
     });
     describe('when the operator is not approved', function () {
       it('reverts', async function () {
-        await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+        await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
         await shouldFail.reverting(this.token.transferFromWithData(tokenHolder, recipient, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator }));
       });
     });
@@ -1157,7 +1139,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
     describe('when defaultPartitions have been defined', function () {
       describe('when the sender has enough balance for those default partitions', function () {
         it('redeeems the requested amount', async function () {
-          await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+          await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
           await assertBalances(this.token, tokenHolder, partitions, [issuanceAmount, issuanceAmount, issuanceAmount]);
 
           await this.token.redeem(2.5 * issuanceAmount, VALID_CERTIFICATE, { from: tokenHolder });
@@ -1165,7 +1147,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
           await assertBalances(this.token, tokenHolder, partitions, [0, 0.5 * issuanceAmount, 0]);
         });
         it('emits a redeemedByPartition events', async function () {
-          await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+          await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
           const { logs } = await this.token.redeem(2.5 * issuanceAmount, VALID_CERTIFICATE, { from: tokenHolder });
 
           assert.equal(logs.length, 1 + 2 * partitions.length);
@@ -1177,14 +1159,14 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
       });
       describe('when the sender does not have enough balance for those default partitions', function () {
         it('reverts', async function () {
-          await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+          await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
           await shouldFail.reverting(this.token.redeem(3.5 * issuanceAmount, VALID_CERTIFICATE, { from: tokenHolder }));
         });
       });
     });
     describe('when defaultPartitions have not been defined', function () {
       it('reverts', async function () {
-        await this.token.setTokenDefaultPartitions([], { from: owner });
+        await this.token.setDefaultPartitions([], { from: owner });
         await shouldFail.reverting(this.token.redeem(2.5 * issuanceAmount, VALID_CERTIFICATE, { from: tokenHolder }));
       });
     });
@@ -1204,7 +1186,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
       describe('when defaultPartitions have been defined', function () {
         describe('when the sender has enough balance for those default partitions', function () {
           it('redeems the requested amount (when sender is specified)', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             await assertBalances(this.token, tokenHolder, partitions, [issuanceAmount, issuanceAmount, issuanceAmount]);
 
             await this.token.redeemFrom(tokenHolder, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator });
@@ -1212,7 +1194,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
             await assertBalances(this.token, tokenHolder, partitions, [0, 0.5 * issuanceAmount, 0]);
           });
           it('redeems the requested amount (when sender is not specified)', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             await assertBalances(this.token, tokenHolder, partitions, [issuanceAmount, issuanceAmount, issuanceAmount]);
 
             await this.token.redeemFrom(ZERO_ADDRESS, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: tokenHolder });
@@ -1220,7 +1202,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
             await assertBalances(this.token, tokenHolder, partitions, [0, 0.5 * issuanceAmount, 0]);
           });
           it('emits redeemedByPartition events', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             const { logs } = await this.token.redeemFrom(tokenHolder, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator });
 
             assert.equal(logs.length, 1 + 2 * partitions.length);
@@ -1232,21 +1214,21 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
         });
         describe('when the sender does not have enough balance for those default partitions', function () {
           it('reverts', async function () {
-            await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+            await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
             await shouldFail.reverting(this.token.redeemFrom(tokenHolder, 3.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator }));
           });
         });
       });
       describe('when defaultPartitions have not been defined', function () {
         it('reverts', async function () {
-          await this.token.setTokenDefaultPartitions([], { from: owner });
+          await this.token.setDefaultPartitions([], { from: owner });
           await shouldFail.reverting(this.token.redeemFrom(tokenHolder, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator }));
         });
       });
     });
     describe('when the operator is not approved', function () {
       it('reverts', async function () {
-        await this.token.setDefaultPartitions(reversedPartitions, { from: tokenHolder });
+        await this.token.setDefaultPartitions(reversedPartitions, { from: owner });
         await shouldFail.reverting(this.token.redeemFrom(tokenHolder, 2.5 * issuanceAmount, ZERO_BYTE, VALID_CERTIFICATE, { from: operator }));
       });
     });

--- a/test/ERC1400ERC20.test.js
+++ b/test/ERC1400ERC20.test.js
@@ -92,7 +92,6 @@ contract('ERC1400ERC20', function ([owner, operator, controller, tokenHolder, re
     const amount = 10;
     beforeEach(async function () {
       await this.token.issueByPartition(partition1, tokenHolder, issuanceAmount, VALID_CERTIFICATE, { from: owner });
-      await this.token.setDefaultPartitions([partition1, partition2, partition3], { from: tokenHolder });
     });
     it('transfers the requested amount', async function () {
       await this.token.transferWithData(to, amount, VALID_CERTIFICATE, { from: tokenHolder });
@@ -139,7 +138,6 @@ contract('ERC1400ERC20', function ([owner, operator, controller, tokenHolder, re
     const redeemAmount = 300;
     beforeEach(async function () {
       await this.token.issueByPartition(partition1, tokenHolder, issuanceAmount, VALID_CERTIFICATE, { from: owner });
-      await this.token.setDefaultPartitions([partition1, partition2, partition3], { from: tokenHolder });
     });
     it('redeems the requested amount', async function () {
       await this.token.redeemByPartition(partition1, redeemAmount, VALID_CERTIFICATE, { from: tokenHolder });
@@ -261,12 +259,12 @@ contract('ERC1400ERC20', function ([owner, operator, controller, tokenHolder, re
   describe('transfer', function () {
     const to = recipient;
     beforeEach(async function () {
+      await this.token.setWhitelisted(tokenHolder, true, { from: owner });
       await this.token.setWhitelisted(to, true, { from: owner });
       await this.token.issueByPartition(partition1, tokenHolder, issuanceAmount, VALID_CERTIFICATE, { from: owner });
-      await this.token.setDefaultPartitions([partition1, partition2, partition3], { from: tokenHolder });
     });
 
-    describe('when the recipient is whitelisted', function () {
+    describe('when the sender and the recipient are whitelisted', function () {
       describe('when the amount is a multiple of the granularity', function () {
         describe('when the recipient is not the zero address', function () {
           describe('when the sender does not have enough balance', function () {
@@ -332,9 +330,16 @@ contract('ERC1400ERC20', function ([owner, operator, controller, tokenHolder, re
         it('reverts', async function () {
           this.token = await ERC1400ERC20.new('ERC777Token', 'DAU', 2, [], CERTIFICATE_SIGNER, partitions);
           await this.token.issueByPartition(partition1, tokenHolder, issuanceAmount, VALID_CERTIFICATE, { from: owner });
-          await this.token.setDefaultPartitions([partition1, partition2, partition3], { from: tokenHolder });
           await shouldFail.reverting(this.token.transfer(to, 3, { from: tokenHolder }));
         });
+      });
+    });
+    describe('when the sender is not whitelisted', function () {
+      const amount = issuanceAmount;
+
+      it('reverts', async function () {
+        await this.token.setWhitelisted(tokenHolder, false, { from: owner });
+        await shouldFail.reverting(this.token.transfer(to, amount, { from: tokenHolder }));
       });
     });
     describe('when the recipient is not whitelisted', function () {
@@ -353,13 +358,12 @@ contract('ERC1400ERC20', function ([owner, operator, controller, tokenHolder, re
     const to = recipient;
     const approvedAmount = 10000;
     beforeEach(async function () {
+      await this.token.setWhitelisted(tokenHolder, true, { from: owner });
       await this.token.setWhitelisted(to, true, { from: owner });
       await this.token.issueByPartition(partition1, tokenHolder, issuanceAmount, VALID_CERTIFICATE, { from: owner });
-      await this.token.setDefaultPartitions([partition1, partition2, partition3], { from: tokenHolder });
-      await this.token.setDefaultPartitions([partition1, partition2, partition3], { from: operator });
     });
 
-    describe('when the recipient is whitelisted', function () {
+    describe('when the sender and the recipient are whitelisted', function () {
       describe('when the operator is approved', function () {
         beforeEach(async function () {
           // await this.token.authorizeOperator(operator, { from: tokenHolder});
@@ -372,22 +376,6 @@ contract('ERC1400ERC20', function ([owner, operator, controller, tokenHolder, re
 
               it('reverts', async function () {
                 await shouldFail.reverting(this.token.transferFrom(tokenHolder, to, amount, { from: operator }));
-              });
-            });
-
-            describe('when the sender has enough balance + the sender is not specified', function () {
-              const amount = 500;
-
-              it('transfers the requested amount from operator address', async function () {
-                await this.token.setWhitelisted(operator, true, { from: owner });
-                await this.token.transfer(operator, approvedAmount, { from: tokenHolder });
-
-                await this.token.transferFrom(ZERO_ADDRESS, to, amount, { from: operator });
-                const senderBalance = await this.token.balanceOf(operator);
-                assert.equal(senderBalance, approvedAmount - amount);
-
-                const recipientBalance = await this.token.balanceOf(to);
-                assert.equal(recipientBalance, amount);
               });
             });
 
@@ -448,7 +436,6 @@ contract('ERC1400ERC20', function ([owner, operator, controller, tokenHolder, re
           it('reverts', async function () {
             this.token = await ERC1400ERC20.new('ERC777Token', 'DAU', 2, [], CERTIFICATE_SIGNER, partitions);
             await this.token.issueByPartition(partition1, tokenHolder, issuanceAmount, VALID_CERTIFICATE, { from: owner });
-            await this.token.setDefaultPartitions([partition1, partition2, partition3], { from: tokenHolder });
             await shouldFail.reverting(this.token.transferFrom(tokenHolder, to, 3, { from: operator }));
           });
         });
@@ -473,6 +460,13 @@ contract('ERC1400ERC20', function ([owner, operator, controller, tokenHolder, re
             await shouldFail.reverting(this.token.transferFrom(tokenHolder, to, amount, { from: operator }));
           });
         });
+      });
+    });
+    describe('when the sender is not whitelisted', function () {
+      const amount = approvedAmount;
+      it('reverts', async function () {
+        await this.token.setWhitelisted(tokenHolder, false, { from: owner });
+        await shouldFail.reverting(this.token.transferFrom(tokenHolder, to, amount, { from: operator }));
       });
     });
     describe('when the recipient is not whitelisted', function () {

--- a/test/ERC777ERC20.test.js
+++ b/test/ERC777ERC20.test.js
@@ -213,10 +213,11 @@ contract('ERC777ERC20', function ([owner, operator, controller, tokenHolder, rec
       const to = recipient;
       beforeEach(async function () {
         await this.token.issue(tokenHolder, initialSupply, VALID_CERTIFICATE, { from: owner });
+        await this.token.setWhitelisted(tokenHolder, true, { from: owner });
         await this.token.setWhitelisted(to, true, { from: owner });
       });
 
-      describe('when the recipient is whitelisted', function () {
+      describe('when the sender and the recipient are whitelisted', function () {
         describe('when the amount is a multiple of the granularity', function () {
           describe('when the recipient is not the zero address', function () {
             describe('when the sender does not have enough balance', function () {
@@ -276,6 +277,14 @@ contract('ERC777ERC20', function ([owner, operator, controller, tokenHolder, rec
           });
         });
       });
+      describe('when the sender is not whitelisted', function () {
+        const amount = initialSupply;
+
+        it('reverts', async function () {
+          await this.token.setWhitelisted(tokenHolder, false, { from: owner });
+          await shouldFail.reverting(this.token.transfer(to, amount, { from: tokenHolder }));
+        });
+      });
       describe('when the recipient is not whitelisted', function () {
         const amount = initialSupply;
 
@@ -293,6 +302,7 @@ contract('ERC777ERC20', function ([owner, operator, controller, tokenHolder, rec
       const approvedAmount = 10000;
       beforeEach(async function () {
         await this.token.issue(tokenHolder, initialSupply, VALID_CERTIFICATE, { from: owner });
+        await this.token.setWhitelisted(tokenHolder, true, { from: owner });
         await this.token.setWhitelisted(to, true, { from: owner });
       });
 
@@ -308,22 +318,6 @@ contract('ERC777ERC20', function ([owner, operator, controller, tokenHolder, rec
 
                 it('reverts', async function () {
                   await shouldFail.reverting(this.token.transferFrom(tokenHolder, to, amount, { from: operator }));
-                });
-              });
-
-              describe('when the sender has enough balance + the sender is not specified', function () {
-                const amount = 500;
-
-                it('transfers the requested amount from operator address', async function () {
-                  await this.token.setWhitelisted(operator, true, { from: owner });
-                  await this.token.transfer(operator, approvedAmount, { from: tokenHolder });
-
-                  await this.token.transferFrom(ZERO_ADDRESS, to, amount, { from: operator });
-                  const senderBalance = await this.token.balanceOf(operator);
-                  assert.equal(senderBalance, approvedAmount - amount);
-
-                  const recipientBalance = await this.token.balanceOf(to);
-                  assert.equal(recipientBalance, amount);
                 });
               });
 


### PR DESCRIPTION
**Issue 6.1 ERC1400ERC20 whitelist circumvents partition restrictions**
https://github.com/ConsenSys/codefi-audit-report-2019-06/#61-erc1400erc20-whitelist-circumvents-partition-restrictions

**Remediation chosen**:
1)Require whitelisting both the sender and recipient, and make sure that whitelisted accounts only own (and will only own) unrestricted tokens.
4)Don't allow token holders to set their own default partitions. Rather, have the token specify a single, unrestricted partition that is used for all ERC20 transfers.