### PR TITLE
feat(ERC777 naming): Rename ERC777TokenRecipient and ERC777TokenSende…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ This repo contains security token smart contract implementations used by CoFi OS
 
  - Empowerment of operators with the ability to send tokens on behalf of other addresses.
  - Setup of send/receive hooks to offer token holders more control over their tokens.
- - Use of ER820([eips.ethereum.org/EIPS/eip-820](https://eips.ethereum.org/EIPS/eip-820)) to notify contracts and regular addresses when they receive tokens.
+ - Use of ERC1820([eips.ethereum.org/EIPS/eip-1820](http://eips.ethereum.org/EIPS/eip-1820)) to notify contracts and regular addresses when they receive tokens.
  - Backwards compatible with ERC20.
+
+ CAUTION: The token standard implementation contained in this repo is not 100% compliant with the official ERC777 interface. The purpose of this choice was to keep the ERC777 logic, while:
+  - Enhancing it with ERC1400-compliant hooks, supporting partitions (IERC1400TokensRecipient and IERC1400TokensSender instead of IERC777TokensRecipient and IERC777TokensSender)
+  - Renaming the functions for more consistency with ERC20 and ERC1400 function (ERC20-transfer, ERC777-transferWithData, ERC1400-transferByPartition)
 
 
 #### ERC1400 implementation - Partially fungible token standard
@@ -101,7 +105,7 @@ The official proposal can be found at: [eips.ethereum.org/EIPS/eip-777](https://
 We've performed a few updates compared to the official proposal, mainly to better fit with our implementation of ERC1400:
  - Introduction of the notion of 'controllers' (replacing defaultOperators) for better consistency with ERC1400 'controllers'.
  - Introduction of '_isControllable' property (set to 'false' by default for the ERC777, but set to 'true' for the ERC1400).
- - Update of IERC777TokensRecipient and IERC777TokensSender interfaces, by adding 'partition' parameters, in order to make the hooks ERC1400-compliant.
+ - Update of IERC777TokensRecipient and IERC777TokensSender interfaces, by adding 'partition' parameters, and renaming into IERC1400TokensRecipient and IERC1400TokensSender in order to make the hooks ERC1400-compliant.
  - Renaming of 'send' function (now 'transferWithData') and 'Sent' event (now 'TransferWithData') for better consistency with ERC1400 names + to avoid potential issues with blockchain tools (e.g. Truffle, etc.) considering 'send' as a reserved word.
  - Renaming of 'mint' function (now 'issue') and 'Minted' event (now 'Issued') for better consistency with ERC1400 names.
  - Renaming of 'burn' function (now 'redeem') and 'Burned' event (now 'Redeemed') for better consistency with ERC1400 names.

--- a/contracts/ERC1400.sol
+++ b/contracts/ERC1400.sol
@@ -250,15 +250,15 @@ contract ERC1400 is IERC1400, ERC1410, MinterRole {
 
      address senderImplementation;
      address recipientImplementation;
-     senderImplementation = interfaceAddr(from, "ERC777TokensSender");
-     recipientImplementation = interfaceAddr(to, "ERC777TokensRecipient");
+     senderImplementation = interfaceAddr(from, "ERC1400TokensSender");
+     recipientImplementation = interfaceAddr(to, "ERC1400TokensRecipient");
 
      if((senderImplementation != address(0))
-       && !IERC777TokensSender(senderImplementation).canTransfer(partition, from, to, value, data, operatorData))
+       && !IERC1400TokensSender(senderImplementation).canTransfer(partition, from, to, value, data, operatorData))
        return(hex"A5", "", partition); // Transfer Blocked - Sender not eligible
 
      if((recipientImplementation != address(0))
-       && !IERC777TokensRecipient(recipientImplementation).canReceive(partition, from, to, value, data, operatorData))
+       && !IERC1400TokensRecipient(recipientImplementation).canReceive(partition, from, to, value, data, operatorData))
        return(hex"A6", "", partition); // Transfer Blocked - Receiver not eligible
 
      if(!_isMultiple(value))

--- a/contracts/mocks/ERC777TokensRecipientMock.sol
+++ b/contracts/mocks/ERC777TokensRecipientMock.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.0;
 
-import "../token/ERC777/IERC777TokensRecipient.sol";
+import "../token/ERC777/IERC1400TokensRecipient.sol";
 import "./ERC1820ImplementerMock.sol";
 
 
-contract ERC777TokensRecipientMock is IERC777TokensRecipient, ERC1820ImplementerMock {
+contract ERC1400TokensRecipientMock is IERC1400TokensRecipient, ERC1820ImplementerMock {
 
   constructor(string memory interfaceLabel)
     public

--- a/contracts/mocks/ERC777TokensSenderMock.sol
+++ b/contracts/mocks/ERC777TokensSenderMock.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.0;
 
-import "../token/ERC777/IERC777TokensSender.sol";
+import "../token/ERC777/IERC1400TokensSender.sol";
 import "./ERC1820ImplementerMock.sol";
 
 
-contract ERC777TokensSenderMock is IERC777TokensSender, ERC1820ImplementerMock {
+contract ERC1400TokensSenderMock is IERC1400TokensSender, ERC1820ImplementerMock {
 
   constructor(string memory interfaceLabel)
     public

--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -12,8 +12,8 @@ import "erc1820/contracts/ERC1820Client.sol";
 import "../../CertificateController/CertificateController.sol";
 
 import "./IERC777.sol";
-import "./IERC777TokensSender.sol";
-import "./IERC777TokensRecipient.sol";
+import "./IERC1400TokensSender.sol";
+import "./IERC1400TokensRecipient.sol";
 
 
 /**
@@ -75,7 +75,7 @@ contract ERC777 is IERC777, Ownable, ERC1820Client, CertificateController, Reent
 
     _setControllers(controllers);
 
-    setInterfaceImplementation("ERC777Token", address(this));
+    setInterfaceImplementation("ERC777LikeToken", address(this));
   }
 
   /********************** ERC777 EXTERNAL FUNCTIONS ***************************/
@@ -343,7 +343,7 @@ contract ERC777 is IERC777, Ownable, ERC1820Client, CertificateController, Reent
 
   /**
    * [INTERNAL]
-   * @dev Check for 'ERC777TokensSender' hook on the sender and call it.
+   * @dev Check for 'ERC1400TokensSender' hook on the sender and call it.
    * May throw according to 'preventLocking'.
    * @param partition Name of the partition (bytes32 to be left empty for ERC777 transfer).
    * @param operator Address which triggered the balance decrease (through transfer or redemption).
@@ -365,16 +365,16 @@ contract ERC777 is IERC777, Ownable, ERC1820Client, CertificateController, Reent
     internal
   {
     address senderImplementation;
-    senderImplementation = interfaceAddr(from, "ERC777TokensSender");
+    senderImplementation = interfaceAddr(from, "ERC1400TokensSender");
 
     if (senderImplementation != address(0)) {
-      IERC777TokensSender(senderImplementation).tokensToTransfer(partition, operator, from, to, value, data, operatorData);
+      IERC1400TokensSender(senderImplementation).tokensToTransfer(partition, operator, from, to, value, data, operatorData);
     }
   }
 
   /**
    * [INTERNAL]
-   * @dev Check for 'ERC777TokensRecipient' hook on the recipient and call it.
+   * @dev Check for 'ERC1400TokensRecipient' hook on the recipient and call it.
    * May throw according to 'preventLocking'.
    * @param partition Name of the partition (bytes32 to be left empty for ERC777 transfer).
    * @param operator Address which triggered the balance increase (through transfer or issuance).
@@ -384,7 +384,7 @@ contract ERC777 is IERC777, Ownable, ERC1820Client, CertificateController, Reent
    * @param data Extra information, intended for the token holder ('from').
    * @param operatorData Extra information attached by the operator (if any).
    * @param preventLocking 'true' if you want this function to throw when tokens are sent to a contract not
-   * implementing 'ERC777TokensRecipient'.
+   * implementing 'ERC1400TokensRecipient'.
    * ERC777 native transfer functions MUST set this parameter to 'true', and backwards compatible ERC20 transfer
    * functions SHOULD set this parameter to 'false'.
    */
@@ -401,10 +401,10 @@ contract ERC777 is IERC777, Ownable, ERC1820Client, CertificateController, Reent
     internal
   {
     address recipientImplementation;
-    recipientImplementation = interfaceAddr(to, "ERC777TokensRecipient");
+    recipientImplementation = interfaceAddr(to, "ERC1400TokensRecipient");
 
     if (recipientImplementation != address(0)) {
-      IERC777TokensRecipient(recipientImplementation).tokensReceived(partition, operator, from, to, value, data, operatorData);
+      IERC1400TokensRecipient(recipientImplementation).tokensReceived(partition, operator, from, to, value, data, operatorData);
     } else if (preventLocking) {
       require(_isRegularAddress(to), "A6: Transfer Blocked - Receiver not eligible");
     }

--- a/contracts/token/ERC777/IERC1400TokensRecipient.sol
+++ b/contracts/token/ERC777/IERC1400TokensRecipient.sol
@@ -5,10 +5,10 @@
 pragma solidity ^0.5.0;
 
 /**
- * @title IERC777TokensRecipient
- * @dev ERC777TokensRecipient interface
+ * @title IERC1400TokensRecipient
+ * @dev ERC1400TokensRecipient interface
  */
-interface IERC777TokensRecipient {
+interface IERC1400TokensRecipient {
 
   function canReceive(
     bytes32 partition,

--- a/contracts/token/ERC777/IERC1400TokensSender.sol
+++ b/contracts/token/ERC777/IERC1400TokensSender.sol
@@ -5,10 +5,10 @@
 pragma solidity ^0.5.0;
 
 /**
- * @title IERC777TokensSender
- * @dev ERC777TokensSender interface
+ * @title IERC1400TokensSender
+ * @dev ERC1400TokensSender interface
  */
-interface IERC777TokensSender {
+interface IERC1400TokensSender {
 
   function canTransfer(
     bytes32 partition,

--- a/test/ERC1400.test.js
+++ b/test/ERC1400.test.js
@@ -3,8 +3,8 @@ import { shouldFail } from 'openzeppelin-test-helpers';
 const ERC1400 = artifacts.require('ERC1400');
 const ERC1410 = artifacts.require('ERC1410Mock');
 const ERC1820Registry = artifacts.require('ERC1820Registry');
-const ERC777TokensSender = artifacts.require('ERC777TokensSenderMock');
-const ERC777TokensRecipient = artifacts.require('ERC777TokensRecipientMock');
+const ERC1400TokensSender = artifacts.require('ERC1400TokensSenderMock');
+const ERC1400TokensRecipient = artifacts.require('ERC1400TokensRecipientMock');
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const ZERO_BYTE = '0x';
@@ -236,11 +236,11 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
     before(async function () {
       this.registry = await ERC1820Registry.at('0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24');
 
-      this.senderContract = await ERC777TokensSender.new('ERC777TokensSender', { from: tokenHolder });
+      this.senderContract = await ERC1400TokensSender.new('ERC1400TokensSender', { from: tokenHolder });
       await this.registry.setManager(tokenHolder, this.senderContract.address, { from: tokenHolder });
       await this.senderContract.setERC1820Implementer({ from: tokenHolder });
 
-      this.recipientContract = await ERC777TokensRecipient.new('ERC777TokensRecipient', { from: recipient });
+      this.recipientContract = await ERC1400TokensRecipient.new('ERC1400TokensRecipient', { from: recipient });
       await this.registry.setManager(recipient, this.recipientContract.address, { from: recipient });
       await this.recipientContract.setERC1820Implementer({ from: recipient });
     });

--- a/test/ERC777.test.js
+++ b/test/ERC777.test.js
@@ -2,8 +2,8 @@ import { shouldFail } from 'openzeppelin-test-helpers';
 
 const ERC777 = artifacts.require('ERC777Mock');
 const ERC1820Registry = artifacts.require('ERC1820Registry');
-const ERC777TokensSender = artifacts.require('ERC777TokensSenderMock');
-const ERC777TokensRecipient = artifacts.require('ERC777TokensRecipientMock');
+const ERC1400TokensSender = artifacts.require('ERC1400TokensSenderMock');
+const ERC1400TokensRecipient = artifacts.require('ERC1400TokensRecipientMock');
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const ZERO_BYTE = '0x';
@@ -553,11 +553,11 @@ contract('ERC777 with hooks', function ([owner, operator, controller, tokenHolde
       this.token = await ERC777.new('ERC777Token', 'DAU', 1, [controller], CERTIFICATE_SIGNER);
       this.registry = await ERC1820Registry.at('0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24');
 
-      this.senderContract = await ERC777TokensSender.new('ERC777TokensSender', { from: tokenHolder });
+      this.senderContract = await ERC1400TokensSender.new('ERC1400TokensSender', { from: tokenHolder });
       await this.registry.setManager(tokenHolder, this.senderContract.address, { from: tokenHolder });
       await this.senderContract.setERC1820Implementer({ from: tokenHolder });
 
-      this.recipientContract = await ERC777TokensRecipient.new('ERC777TokensRecipient', { from: recipient });
+      this.recipientContract = await ERC1400TokensRecipient.new('ERC1400TokensRecipient', { from: recipient });
       await this.registry.setManager(recipient, this.recipientContract.address, { from: recipient });
       await this.recipientContract.setERC1820Implementer({ from: recipient });
 


### PR DESCRIPTION
**Issue 6.4 ERC777 incompatibilities**

As noted in the README, the ERC777 contract is not actually compatible with ERC 777.

Functions and events have been renamed, and the hooks ERC777TokensRecipient and ERC777TokensSender have been modified to add a partition parameter.

This means no tools that deal with standard ERC 777 contracts will work with this code's tokens.

**Remediation chosen**:

- Rename ERC777TokenRecipient and ERC777TokenSender into ERC1400TokenRecipient and ERC1400TokenSender
- Don't set interface implementation as "ERC777Token" in ERC1820 registry (use "ERC777LikeToken" instead)