### PR TITLE
feat(changePartition): Check length of flag to avoid buffer over-read

### DIFF
--- a/contracts/token/ERC1410/ERC1410.sol
+++ b/contracts/token/ERC1410/ERC1410.sol
@@ -260,7 +260,7 @@ contract ERC1410 is IERC1410, ERC777 {
 
     bytes32 toPartition = fromPartition;
 
-    if(operatorData.length != 0 && data.length != 0) {
+    if(operatorData.length != 0 && data.length >= 64) {
       toPartition = _getDestinationPartition(fromPartition, data);
     }
 

--- a/test/ERC1400.test.js
+++ b/test/ERC1400.test.js
@@ -23,12 +23,14 @@ const INVALID_CERTIFICATE_SENDER = '0x110000000000000000000000000000000000000000
 const INVALID_CERTIFICATE_RECIPIENT = '0x2200000000000000000000000000000000000000000000000000000000000000';
 
 const partitionFlag = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'; // Flag to indicate a partition change
+const otherFlag = '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'; // Other flag
 const partition1_short = '5265736572766564000000000000000000000000000000000000000000000000'; // Reserved in hex
 const partition2_short = '4973737565640000000000000000000000000000000000000000000000000000'; // Issued in hex
 const partition3_short = '4c6f636b65640000000000000000000000000000000000000000000000000000'; // Locked in hex
 const changeToPartition1 = partitionFlag.concat(partition1_short);
 const changeToPartition2 = partitionFlag.concat(partition2_short);
 const changeToPartition3 = partitionFlag.concat(partition3_short);
+const doNotChangePartition = otherFlag.concat(partition2_short);
 const partition1 = '0x'.concat(partition1_short);
 const partition2 = '0x'.concat(partition2_short);
 const partition3 = '0x'.concat(partition3_short);
@@ -871,7 +873,7 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
             await assertBalanceOf(this.token, recipient, partition1, 0);
 
             await this.token.authorizeOperatorByPartition(partition1, operator, { from: tokenHolder });
-            await this.token.operatorTransferByPartition(partition1, tokenHolder, recipient, transferAmount, partition2, VALID_CERTIFICATE, { from: operator });
+            await this.token.operatorTransferByPartition(partition1, tokenHolder, recipient, transferAmount, doNotChangePartition, VALID_CERTIFICATE, { from: operator });
 
             await assertBalanceOf(this.token, tokenHolder, partition1, issuanceAmount - transferAmount);
             await assertBalanceOf(this.token, recipient, partition1, transferAmount);


### PR DESCRIPTION
**Issue 6.5 Buffer over-read in ERC1410._getDestinationPartition**

There's no check that data is at least 64 bytes long in function `_getDestinationPartition`.
Depending on how the compiler chooses to lay out memory, the next data in memory is probably the operatorDatabuffer, so data may inadvertently be read from there.

**Remediation chosen**:

Check for sufficient length (at least 64 bytes) before attempting to read it.