### PR TITLE
feat(preventLocking): Make sure that ERC20-compatible transfer calls …

### DIFF
--- a/contracts/token/ERC20/ERC1400ERC20.sol
+++ b/contracts/token/ERC20/ERC1400ERC20.sol
@@ -165,7 +165,7 @@ contract ERC1400ERC20 is IERC20, ERC1400 {
    * @return A boolean that indicates if the operation was successful.
    */
   function transfer(address to, uint256 value) external isWhitelisted(to) returns (bool) {
-    _transferByDefaultPartitions(msg.sender, msg.sender, to, value, "", "");
+    _transferByDefaultPartitions(msg.sender, msg.sender, to, value, "", "", false);
     return true;
   }
 
@@ -188,7 +188,7 @@ contract ERC1400ERC20 is IERC20, ERC1400 {
       _allowed[_from][msg.sender] = 0;
     }
 
-    _transferByDefaultPartitions(msg.sender, _from, to, value, "", "");
+    _transferByDefaultPartitions(msg.sender, _from, to, value, "", "", false);
     return true;
   }
 


### PR DESCRIPTION
**Issue 6.6 ERC20/ERC777 compatibility: ERC20 transfer functions should not revert if the recipient is a contract without a registered ERC777TokensRecipient implementation**

The ERC20 functions ERC1400ERC20.transfer and ERC1400ERC20.transferFrom call ERC1410._transferByDefaultPartitions, which calls ERC1410._transferByPartition, which calls ERC777._transferWithData with the preventLocking argument of true.
This will block transfers to a contract that doesn't have an ERC777TokensRecipient implementation. This is in violation of ERC 777.

**Remediation chosen**:

Make sure that ERC20-compatible transfer calls do not set preventLocking to true.