### PR TITLE
feat(authorize/revoke): Forbid a holder to auhtorize/revoke himself

### DIFF
--- a/contracts/token/ERC777/ERC777.sol
+++ b/contracts/token/ERC777/ERC777.sol
@@ -142,6 +142,7 @@ contract ERC777 is IERC777, Ownable, ERC1820Client, CertificateController, Reent
    * @param operator Address to set as an operator for 'msg.sender'.
    */
   function authorizeOperator(address operator) external {
+    require(operator != msg.sender);
     _authorizedOperator[operator][msg.sender] = true;
     emit AuthorizedOperator(operator, msg.sender);
   }
@@ -153,6 +154,7 @@ contract ERC777 is IERC777, Ownable, ERC1820Client, CertificateController, Reent
    * @param operator Address to rescind as an operator for 'msg.sender'.
    */
   function revokeOperator(address operator) external {
+    require(operator != msg.sender);
     _authorizedOperator[operator][msg.sender] = false;
     emit RevokedOperator(operator, msg.sender);
   }

--- a/test/ERC777.test.js
+++ b/test/ERC777.test.js
@@ -128,6 +128,11 @@ contract('ERC777 without hooks', function ([owner, operator, controller, control
           assert.equal(logs[0].args.tokenHolder, tokenHolder);
         });
       });
+      describe('when sender authorizes himself', function () {
+        it('reverts', async function () {
+          await shouldFail.reverting(this.token.authorizeOperator(tokenHolder, { from: tokenHolder }));
+        });
+      });
     });
 
     describe('revokeOperator', function () {
@@ -148,6 +153,11 @@ contract('ERC777 without hooks', function ([owner, operator, controller, control
           assert.equal(logs[0].event, 'RevokedOperator');
           assert.equal(logs[0].args.operator, controller);
           assert.equal(logs[0].args.tokenHolder, tokenHolder);
+        });
+      });
+      describe('when sender revokes himself', function () {
+        it('reverts', async function () {
+          await shouldFail.reverting(this.token.revokeOperator(tokenHolder, { from: tokenHolder }));
         });
       });
     });


### PR DESCRIPTION
**Issue 6.7 ERC777 compatibility: authorizeOperator and revokeOperator should revert when the caller and operator are the same account**

A user shall not be able to call `authorizeOperator` or `revokeOperator` for himself.

**Remediation chosen**:

Add require(operator != msg.sender) to those two functions.