### PR TITLE
feat(redeem and redeemFrom): Replace silent functions by revert()

### DIFF
--- a/contracts/token/ERC1410/ERC1410.sol
+++ b/contracts/token/ERC1410/ERC1410.sol
@@ -443,6 +443,7 @@ contract ERC1410 is IERC1410, ERC777 {
    * @dev Empty function to erase ERC777 redeem() function since it doesn't handle partitions.
    */
   function redeem(uint256 /*value*/, bytes calldata /*data*/) external { // Comments to avoid compilation warnings for unused variables.
+    revert("A8: Transfer Blocked - Token restriction");
   }
 
   /**
@@ -450,6 +451,7 @@ contract ERC1410 is IERC1410, ERC777 {
    * @dev Empty function to erase ERC777 redeemFrom() function since it doesn't handle partitions.
    */
   function redeemFrom(address /*from*/, uint256 /*value*/, bytes calldata /*data*/, bytes calldata /*operatorData*/) external { // Comments to avoid compilation warnings for unused variables.
+    revert("A8: Transfer Blocked - Token restriction");
   }
 
   /**

--- a/test/ERC1400.test.js
+++ b/test/ERC1400.test.js
@@ -1260,10 +1260,14 @@ contract('ERC1410', function ([owner, operator, controller, controller_alternati
     beforeEach(async function () {
       this.token = await ERC1410.new('ERC1410Token', 'DAU', 1, [controller], CERTIFICATE_SIGNER, partitions, tokenHolder, 1000);
     });
-    it('redeem function is disactivated', async function () {
+    // it('redeem function is disactivated', async function () {
+    //   await assertBalance(this.token, tokenHolder, 1000);
+    //   await this.token.redeem(500, VALID_CERTIFICATE, { from: tokenHolder });
+    //   await assertBalance(this.token, tokenHolder, 1000);
+    // });
+    it('reverts', async function () {
       await assertBalance(this.token, tokenHolder, 1000);
-      await this.token.redeem(500, VALID_CERTIFICATE, { from: tokenHolder });
-      await assertBalance(this.token, tokenHolder, 1000);
+      await shouldFail.reverting(this.token.redeem(500, VALID_CERTIFICATE, { from: tokenHolder }));
     });
   });
 
@@ -1273,11 +1277,16 @@ contract('ERC1410', function ([owner, operator, controller, controller_alternati
     beforeEach(async function () {
       this.token = await ERC1410.new('ERC1410Token', 'DAU', 1, [controller], CERTIFICATE_SIGNER, partitions, tokenHolder, 1000);
     });
-    it('redeemFrom function is disactivated', async function () {
+    // it('redeemFrom function is disactivated', async function () {
+    //   await this.token.authorizeOperator(operator, { from: tokenHolder });
+    //   await assertBalance(this.token, tokenHolder, 1000);
+    //   await this.token.redeemFrom(tokenHolder, 500, ZERO_BYTE, VALID_CERTIFICATE, { from: operator });
+    //   await assertBalance(this.token, tokenHolder, 1000);
+    // });
+    it('reverts', async function () {
       await this.token.authorizeOperator(operator, { from: tokenHolder });
       await assertBalance(this.token, tokenHolder, 1000);
-      await this.token.redeemFrom(tokenHolder, 500, ZERO_BYTE, VALID_CERTIFICATE, { from: operator });
-      await assertBalance(this.token, tokenHolder, 1000);
+      await shouldFail.reverting(this.token.redeemFrom(tokenHolder, 500, ZERO_BYTE, VALID_CERTIFICATE, { from: operator }));
     });
   });
 });


### PR DESCRIPTION
**Issue 6.11 ERC1410's redeem and redeemFrom should revert**

ERC1410 contains two functions: redeem and redeemFrom that "erase" the underlying ERC777 versions of these functions because those functions don't handle partitions.
These functions silently succeed, while they should probably fail by reverting.

**Remediation chosen**:

Add a revert() (possibly with a reason) so callers know that the call failed.