### PR TITLE
feat(array deletion): Remove redundant way to reduce size of an array

### DIFF
--- a/contracts/token/ERC1410/ERC1410.sol
+++ b/contracts/token/ERC1410/ERC1410.sol
@@ -293,7 +293,6 @@ contract ERC1410 is IERC1410, ERC777 {
       for (uint i = 0; i < _partitionsOf[from].length; i++) {
         if(_partitionsOf[from][i] == partition) {
           _partitionsOf[from][i] = _partitionsOf[from][_partitionsOf[from].length - 1];
-          delete _partitionsOf[from][_partitionsOf[from].length - 1];
           _partitionsOf[from].length--;
           break;
         }
@@ -305,7 +304,6 @@ contract ERC1410 is IERC1410, ERC777 {
       for (uint i = 0; i < _totalPartitions.length; i++) {
         if(_totalPartitions[i] == partition) {
           _totalPartitions[i] = _totalPartitions[_totalPartitions.length - 1];
-          delete _totalPartitions[_totalPartitions.length - 1];
           _totalPartitions.length--;
           break;
         }


### PR DESCRIPTION
**Issue 6.14 Optimization: redundant delete in ERC1400. _removeTokenFromPartition**

Reducing the size of an array automatically deletes the removed elements, so the first of these two lines is redundant.

**Remediation chosen**:

Remove the redundant deletions to save a little gas.