### PR TITLE
feat(function selector): Replace raw function selector by this.<metho…

### DIFF
--- a/contracts/ERC1400.sol
+++ b/contracts/ERC1400.sol
@@ -181,7 +181,7 @@ contract ERC1400 is IERC1400, ERC1410, MinterRole {
     view
     returns (byte, bytes32, bytes32)
   {
-    if(!_checkCertificate(data, 0, bytes4(this.transferByPartition.selector))) { // 0xf3d490db: 4 first bytes of keccak256(transferByPartition(bytes32,address,uint256,bytes))
+    if(!_checkCertificate(data, 0, this.transferByPartition.selector)) { // 0xf3d490db: 4 first bytes of keccak256(transferByPartition(bytes32,address,uint256,bytes))
       return(hex"A3", "", partition); // Transfer Blocked - Sender lockup period not ended
     } else {
       return _canTransfer(partition, msg.sender, msg.sender, to, value, data, "");

--- a/contracts/ERC1400.sol
+++ b/contracts/ERC1400.sol
@@ -181,7 +181,7 @@ contract ERC1400 is IERC1400, ERC1410, MinterRole {
     view
     returns (byte, bytes32, bytes32)
   {
-    if(!_checkCertificate(data, 0, 0xf3d490db)) { // 4 first bytes of keccak256(transferByPartition(bytes32,address,uint256,bytes))
+    if(!_checkCertificate(data, 0, bytes4(this.transferByPartition.selector))) { // 0xf3d490db: 4 first bytes of keccak256(transferByPartition(bytes32,address,uint256,bytes))
       return(hex"A3", "", partition); // Transfer Blocked - Sender lockup period not ended
     } else {
       return _canTransfer(partition, msg.sender, msg.sender, to, value, data, "");
@@ -208,7 +208,7 @@ contract ERC1400 is IERC1400, ERC1410, MinterRole {
     view
     returns (byte, bytes32, bytes32)
   {
-    if(!_checkCertificate(operatorData, 0, 0x8c0dee9c)) { // 4 first bytes of keccak256(operatorTransferByPartition(bytes32,address,address,uint256,bytes,bytes))
+    if(!_checkCertificate(operatorData, 0, this.operatorTransferByPartition.selector)) { // 0x8c0dee9c: 4 first bytes of keccak256(operatorTransferByPartition(bytes32,address,address,uint256,bytes,bytes))
       return(hex"A3", "", partition); // Transfer Blocked - Sender lockup period not ended
     } else {
       address _from = (from == address(0)) ? msg.sender : from;


### PR DESCRIPTION
**Issue 6.15 Avoid hardcoding function selectors**

In ERC1400, hardcoded function selectors can be replaced with this.transferByPartition.selector and this.operatorTransferByPartition.selector.

**Remediation chosen**:

Replace the hardcoded function selectors with this.<method>.selector.