### PR TITLE
Audit/i6.13

### DIFF
--- a/contracts/token/ERC1410/ERC1410.sol
+++ b/contracts/token/ERC1410/ERC1410.sol
@@ -293,7 +293,6 @@ contract ERC1410 is IERC1410, ERC777 {
       for (uint i = 0; i < _partitionsOf[from].length; i++) {
         if(_partitionsOf[from][i] == partition) {
           _partitionsOf[from][i] = _partitionsOf[from][_partitionsOf[from].length - 1];
-          delete _partitionsOf[from][_partitionsOf[from].length - 1];
           _partitionsOf[from].length--;
           break;
         }
@@ -305,7 +304,6 @@ contract ERC1410 is IERC1410, ERC777 {
       for (uint i = 0; i < _totalPartitions.length; i++) {
         if(_totalPartitions[i] == partition) {
           _totalPartitions[i] = _totalPartitions[_totalPartitions.length - 1];
-          delete _totalPartitions[_totalPartitions.length - 1];
           _totalPartitions.length--;
           break;
         }

--- a/test/ERC1400.test.js
+++ b/test/ERC1400.test.js
@@ -737,9 +737,15 @@ contract('ERC1400', function ([owner, operator, controller, controller_alternati
         assertBurnEvent(logs, partition1, tokenHolder, tokenHolder, redeemAmount, VALID_CERTIFICATE, null);
       });
     });
-    describe('when the redeemer has enough balance for this partition', function () {
+    describe('when the redeemer does not have enough balance for this partition', function () {
       it('reverts', async function () {
         await shouldFail.reverting(this.token.redeemByPartition(partition2, redeemAmount, VALID_CERTIFICATE, { from: tokenHolder }));
+      });
+    });
+    describe('special case (_removeTokenFromPartition shall revert)', function () {
+      it('reverts', async function () {
+        await this.token.issueByPartition(partition2, owner, issuanceAmount, VALID_CERTIFICATE, { from: owner });
+        await shouldFail.reverting(this.token.redeemByPartition(partition2, 0, VALID_CERTIFICATE, { from: tokenHolder }));
       });
     });
   });


### PR DESCRIPTION
**Issue 6.13 Global partition enumeration can run into gas limits**

Finding the partition requires iterating over the entire array. This means that _removeTokenFromPartition can become very expensive and eventually bump up against the block gas limit if lots of partitions are created. This could be an attack vector for a malicious operator.
The same issue applies to a token holder's list of partitions, where transferring tokens in a large number of partitions to that token holder may block them from being able to transfer tokens out.

**Remediation chosen**:

Removing an item from a set can be accomplished in constant time if the set uses both an array (for storing the values) and a mapping of values to their index in that array. See https://programtheblockchain.com/posts/2018/06/03/storage-patterns-set/ for one example of doing this.